### PR TITLE
Calculating statistical measures of a dataset

### DIFF
--- a/src/utils/statistical_measures.py
+++ b/src/utils/statistical_measures.py
@@ -1,0 +1,48 @@
+from typing import Union
+
+import pandas
+
+
+def calculate_statistical_measures(
+    dataset: Union[pandas.DataFrame, pandas.Series, list[float]],
+) -> dict[str, float | None]:
+    """
+    This function calculates statistical measures from a given dataset and returns them in a structured dictionary format.
+
+    Parameters:
+        dataset: Dataset containing a set of values over a time interval.
+
+    Returns:
+        dict: A structured dictionary containing median, mode, standard deviation, and coefficients of variation.
+    """
+
+    if isinstance(dataset, pandas.DataFrame):
+        if "rate" not in dataset.columns:
+            raise ValueError("DataFrame must contain a 'rate' column!")
+        values = dataset["rate"]
+    elif isinstance(dataset, pandas.Series):
+        values = dataset
+    else:
+        values = pandas.Series(dataset)
+
+    if values.empty:
+        raise ValueError("Dataset is empty!")
+
+    median_value = values.median()
+
+    mode_series = values.mode()
+    mode_value = mode_series.iloc[0] if not mode_series.empty else None
+
+    standard_deviation_value = values.std()
+
+    mean_value = values.mean()
+    coefficient_of_variation_value = (
+        standard_deviation_value / mean_value if mean_value != 0 else None
+    )
+
+    return {
+        "median": median_value,
+        "mode": mode_value,
+        "standard_deviation": standard_deviation_value,
+        "coefficient_of_variation": coefficient_of_variation_value,
+    }

--- a/tests/empyt_test.py
+++ b/tests/empyt_test.py
@@ -1,9 +1,0 @@
-import unittest
-
-class MyTestCase(unittest.TestCase):
-    def test_something(self):
-        self.assertEqual(True, True)  # add assertion here
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_statistical_measures.py
+++ b/tests/test_statistical_measures.py
@@ -1,0 +1,69 @@
+import unittest
+
+import pandas as pd
+
+from src.utils.statistical_measures import calculate_statistical_measures
+
+
+class TestCalculateStatisticalMeasures(unittest.TestCase):
+    def test_valid_dataset(self) -> None:
+        df: pd.DataFrame = pd.DataFrame({"rate": [4.0, 4.1, 4.2, 4.1, 4.3, 4.1]})
+        result: dict[str, float | None] = calculate_statistical_measures(df)
+
+        self.assertIn("median", result)
+        self.assertIn("mode", result)
+        self.assertIn("standard_deviation", result)
+        self.assertIn("coefficient_of_variation", result)
+        self.assertIsNotNone(result["median"])
+        self.assertIsNotNone(result["mode"])
+
+        assert result["median"] is not None
+        assert result["mode"] is not None
+
+        self.assertAlmostEqual(result["median"], 4.1)
+        self.assertAlmostEqual(result["mode"], 4.1)
+
+    def test_missing_rate_column(self) -> None:
+        df: pd.DataFrame = pd.DataFrame({"value": [1, 2, 3]})
+
+        with self.assertRaises(ValueError):
+            calculate_statistical_measures(df)
+
+    def test_empty_dataset(self) -> None:
+        df: pd.DataFrame = pd.DataFrame({"rate": []})
+
+        with self.assertRaises(ValueError):
+            calculate_statistical_measures(df)
+
+    def test_multiple_modes_returns_first(self) -> None:
+        df: pd.DataFrame = pd.DataFrame({"rate": [1, 2, 2, 3, 3]})
+        result: dict[str, float | None] = calculate_statistical_measures(df)
+
+        self.assertIn(result["mode"], [2, 3])
+
+    def test_coefficient_of_variation_zero_mean(self) -> None:
+        df: pd.DataFrame = pd.DataFrame({"rate": [0, 0, 0]})
+        result: dict[str, float | None] = calculate_statistical_measures(df)
+
+        self.assertIsNone(result["coefficient_of_variation"])
+
+    def test_simple_array_input(self) -> None:
+        data: list[float] = [4.0, 4.1, 4.2, 4.1, 4.3, 4.1]
+        result: dict[str, float | None] = calculate_statistical_measures(data)
+
+        self.assertIn("median", result)
+        self.assertIn("mode", result)
+        self.assertIn("standard_deviation", result)
+        self.assertIn("coefficient_of_variation", result)
+        self.assertIsNotNone(result["median"])
+        self.assertIsNotNone(result["mode"])
+
+        assert result["median"] is not None
+        assert result["mode"] is not None
+
+        self.assertAlmostEqual(result["median"], 4.1)
+        self.assertAlmostEqual(result["mode"], 4.1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I have added a util function called "calculate_statistical_measures" which calculates the statistical measures (median, mode, standard deviation, coefficient of variation) for the given dataset.

The dataset can be either an exchange rates pandas.DataFrame or just a simple array.

This PR implements functionality described in issue #31 